### PR TITLE
Honor redirect URLs upon logging in and out.

### DIFF
--- a/oidc/plugin.php
+++ b/oidc/plugin.php
@@ -31,6 +31,7 @@ function oidc_auth( $valid ) {
 				if( $id == $hash ) {
 					yourls_set_user($user);
 					$valid = true;
+					header('Refresh:0; url=' . YOURLS_SITE . '/admin');
 				}
 			}
 		}
@@ -42,7 +43,7 @@ yourls_add_action( 'logout', 'oidc_logout' );
 function oidc_logout() {
 	yourls_store_cookie( null );
 	global $oidc;
-	$oidc->signOut( null, YOURLS_SITE );
+	$oidc->signOut( null, YOURLS_SITE . '/admin');
 }
 
 // Largely unchanged: only checking auth against w/ cookies.


### PR DESCRIPTION
The plugin does authorize the user with the Identity Provider but fails to actually load the YOURLS `/admin` page after logging in. (On my system, only a blank page is displayed; one needs to manually refresh the browser in order to proceed.)

No signout page is displayed, either, because the log-out link `YOURLS_SITE` is not a webpage, whereas `YOURLS_SITE/admin` is.

This PR attempts to fix both issues.

Thank you for a very useful plugin.