### PR TITLE
Implement option for custom redirect URL & Fixes sessions for users not in local database

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ $oidc_profiles = array(
 );
 // Option 2, all users on OIDC platform have YOURLS accounts. uses 'preferred_username' attribute
 define( 'OIDC_BYPASS_YOURLS_AUTH', true );
+// If behind Reverse Proxies YOURLS URL might be incorrectly detected for redirects; manually set it here to force redirects to the right page. 
+// Note it points to /admin/ and not the root.
+define( 'OIDC_REDIRECT_URL', 'https://yourls.example.com/admin/' );
 ```
 ### In Development
 - Tight integration with AuthMgrPlus

--- a/oidc/plugin.php
+++ b/oidc/plugin.php
@@ -20,6 +20,8 @@ $oidc = new Jumbojett\OpenIDConnectClient(
 			OIDC_CLIENT_SECRET
 		);
 
+if( defined( 'OIDC_REDIRECT_URL' ) ) $oidc->setRedirectUrl(OIDC_REDIRECT_URL);
+
 yourls_add_filter( 'is_valid_user', 'oidc_auth' );
 function oidc_auth( $valid ) {
 	// check for correct context

--- a/oidc/plugin.php
+++ b/oidc/plugin.php
@@ -4,8 +4,8 @@ Plugin Name: oidc
 Plugin URI: https://github.com/joshp23/YOURLS-OIDC
 Description: Enables OpenID Connect user authentication
 Version: 0.3.1
-Author: Josh Panter
-Author URI: https://unfettered.net
+Author: Josh Panter, Francesco Servida
+Author URI: https://unfettered.net, https://francescoservida.ch
 */
 // No direct call
 if( !defined( 'YOURLS_ABSPATH' ) ) die();
@@ -25,6 +25,14 @@ if( defined( 'OIDC_REDIRECT_URL' ) ) $oidc->setRedirectUrl(OIDC_REDIRECT_URL);
 yourls_add_filter( 'is_valid_user', 'oidc_auth' );
 function oidc_auth( $valid ) {
 	// check for correct context
+	if ( !yourls_is_API() && isset($_COOKIE[yourls_cookie_name()]) ) {
+                if ( isset($_COOKIE['OIDC_username']) ) {
+                        if ( yourls_cookie_value($_COOKIE['OIDC_username']) === $_COOKIE[yourls_cookie_name()] ){
+                                yourls_set_user($_COOKIE['OIDC_username']);
+                                $valid = true;
+                        }
+                }
+        }
 	if ( !yourls_is_API() && !$valid ) {
 		global $oidc;
 		$oidc->authenticate();
@@ -32,6 +40,7 @@ function oidc_auth( $valid ) {
 			$user = $oidc->requestUserInfo('preferred_username');
 			if ( $user ) {
 				yourls_set_user($user);
+				oidc_cookie_login($user);
 				$valid = true;
 			}
 		} else {
@@ -50,11 +59,29 @@ function oidc_auth( $valid ) {
 	return $valid;
 }
 
+function oidc_cookie_login($user){
+        $time = time() + yourls_get_cookie_life();
+        $path     = yourls_apply_filter( 'setcookie_path',     '/' );
+        $domain   = yourls_apply_filter( 'setcookie_domain',   parse_url( yourls_get_yourls_site(), PHP_URL_HOST ) );
+        $secure   = yourls_apply_filter( 'setcookie_secure',   yourls_is_ssl() );
+        $httponly = yourls_apply_filter( 'setcookie_httponly', true );
+        setcookie('OIDC_username', $user, $time, $path, $domain, $secure, $httponly);
+}
+
 yourls_add_action( 'logout', 'oidc_logout' );
 function oidc_logout() {
 	yourls_store_cookie( null );
+	oidc_cookie_logout();
 	global $oidc;
 	$oidc->signOut( null, YOURLS_SITE );
+}
+
+function oidc_cookie_logout(){
+        $path     = yourls_apply_filter( 'setcookie_path',     '/' );
+        $domain   = yourls_apply_filter( 'setcookie_domain',   parse_url( yourls_get_yourls_site(), PHP_URL_HOST ) );
+        $secure   = yourls_apply_filter( 'setcookie_secure',   yourls_is_ssl() );
+        $httponly = yourls_apply_filter( 'setcookie_httponly', true );
+        setcookie("OIDC_username", "", time() - 3600, $path, $domain, $secure, $httponly);
 }
 
 // Largely unchanged: only checking auth against w/ cookies.


### PR DESCRIPTION
When using Yourls behind a reverse proxy apparently jumbojett has trouble detecting the correct URL, as it redirects to /admin and not /admin/ (at least in my setup using yours docker image).
This leads to subsequent broken redirects and http downgrade (probably more of an issue with yourls itself). (see screenshots). Because of the http downgrade, apart from the obvious problem of insecure traffic, this breaks implementations in frames.

I've managed to simply fix this by manually setting the redirect URL that the OIDC plugin uses instead of autodetecting it.
As it might be useful for others I've generalized the solution by reading an optional constant from the config.php file.

![image](https://user-images.githubusercontent.com/501958/166149086-1f540fd9-7254-46bc-ba4f-801369921975.png)
![image](https://user-images.githubusercontent.com/501958/166149088-e6c99300-21e7-4cc5-ad0e-04259756d77a.png)

